### PR TITLE
上传了Merlin和Percival的角色策略类

### DIFF
--- a/merged_version.py
+++ b/merged_version.py
@@ -243,160 +243,275 @@ class RoleStrategy:
             # 好人角色执行成功
             return True
 
+    def assassinate(self, player) -> int:  # Target player index for assassination
+        # Most roles don't assassinate. Assassin role will override this.
+        return -1
+
 # 梅林策略
-class MerlinStrategy(RoleStrategy):
-    def decide_mission_member(self, team_size: int) -> list:
-        """梅林组队：排除已知邪恶，优先信任好人"""
-        candidates = [self.player.index]
-        safe_players = [p for p in self.player.players 
-                       if p not in self.player.trusted_evil and p != self.player.index]
-        
-        # 按信任度排序
-        safe_players.sort(key=lambda p: self.player.suspicion_level[p])
-        
-        # 选择最安全的玩家
-        for p in safe_players:
-            if len(candidates) < team_size:
-                candidates.append(p)
-        
-        # 如果人数不够，随机补充
+class MerlinRoleStrategy(RoleStrategy):
+    def say(self, player) -> str:
+        self_pos = player.player_positions.get(player.index)
+        if not self_pos:
+            return "我还没有确定位置，暂时无法发言。"
+
+        if player.round_num <= 2:  # Early game, very subtle
+            if len(player.trusted_evil) > 0:
+                evil_player = random.choice(list(player.trusted_evil))
+                evil_player_pos = player.player_positions.get(evil_player)
+                # Only hint if evil player's position is known and they are NOT in Merlin's hearing range
+                if evil_player_pos and not player._is_in_range(evil_player_pos, self_pos, player.hearing_range):
+                    return f"我觉得P{evil_player}今天的发言有点奇怪，大家可以多观察一下他/她。"
+            return "大家要多沟通，找出队伍中的不稳定因素。"
+        else:  # Mid-late game, slightly more direct but still cautious
+            if len(player.trusted_evil) > 0:
+                evil_player = random.choice(list(player.trusted_evil))
+                evil_player_pos = player.player_positions.get(evil_player)
+                # Even in later game, prefer to hint about players not directly listening to Merlin, if possible
+                if evil_player_pos and not player._is_in_range(evil_player_pos, self_pos, player.hearing_range):
+                    return f"我们必须警惕P{evil_player}，他/她可能不是好人。"
+                else:  # If evil is in range, be more generic
+                    return "邪恶阵营的成员正在试图混淆视听，请大家警惕！"
+            if len(player.trusted_good) > 0:  # trusted_good is populated by Merlin based on observations
+                good_player = random.choice(list(player.trusted_good))
+                good_player_pos = player.player_positions.get(good_player)
+                if good_player_pos and not player._is_in_range(good_player_pos, self_pos, player.hearing_range):
+                    return f"P{good_player}一直是值得信任的，我支持他/她。"
+                else:
+                    return "我们应该信任那些为团队付出的人。"
+        return "我们需要一个能通过任务的队伍。请大家谨慎选择。"
+
+    def decide_mission_member(self, player, team_size: int) -> list:
+        candidates = []
+        if player.index not in candidates:
+            candidates.append(player.index)
+
+        # Get players Merlin knows are not evil
+        safe_players = [p for p in player.players if p not in player.trusted_evil]
+
+        # Prioritize players Merlin trusts (in player.trusted_good) or has low suspicion of among safe players
+        # Sort by: 1. Is in trusted_good (True first), 2. Suspicion level (lower first)
+        sorted_safe_candidates = sorted(safe_players, key=lambda p_id: (
+        not (p_id in player.trusted_good), player.suspicion_level[p_id]))
+
+        for p_id in sorted_safe_candidates:
+            if p_id not in candidates and len(candidates) < team_size:
+                candidates.append(p_id)
+
+        # If team is still not full, add remaining safe players (excluding self if already added)
+        remaining_safe_to_add = [p_id for p_id in safe_players if p_id not in candidates]
+        while len(candidates) < team_size and remaining_safe_to_add:
+            candidates.append(remaining_safe_to_add.pop(0))  # Add from the start of the sorted list
+
+        # Fallback: if still not enough (e.g. too many evil players), fill with any available player not already on team
+        # This part should ideally not be reached if team_size is reasonable for # of good players
+        all_player_ids = [p_id for p_id in player.players]
         while len(candidates) < team_size:
-            remaining = [p for p in self.player.players if p not in candidates]
-            if remaining:
-                candidates.append(random.choice(remaining))
-            else:
-                break
-        
-        return sorted(candidates[:team_size])
-    
-    def say(self) -> str:
-        """梅林发言：给出暗示但避免过于明显"""
-        current_round = len(self.player.team_history) + 1
-        
-        if current_round <= 2:
-            # 早期保守发言
-            suspicious_players = [p for p in self.player.trusted_evil if random.random() < 0.3]
-            if suspicious_players:
-                target = random.choice(suspicious_players)
-                return f"我觉得P{target}的行为有些可疑，大家要小心观察。"
-            return "我们需要仔细观察每个人的行为模式。"
-        else:
-            # 后期可以更直接一些
-            if self.player.trusted_evil:
-                target = random.choice(list(self.player.trusted_evil))
-                return f"根据之前的观察，P{target}很可能不是我们这边的。"
-            return "我们要团结一致，完成任务。"
-    
-    def mission_vote1(self) -> bool:
-        """梅林投票：避免邪恶玩家过多的队伍"""
-        current_team = self.player.team_history[-1][1] if self.player.team_history else []
-        current_round = len(self.player.team_history)
-        
-        if current_round != 4:  # 非关键轮次
-            for p in current_team:
-                if p in self.player.trusted_evil:
-                    return False
-            return True
-        else:  # 第4轮，更宽松
-            evil_count = sum(1 for p in current_team if p in self.player.trusted_evil)
-            return evil_count <= 1
-    
+            available_players = [p_id for p_id in all_player_ids if p_id not in candidates]
+            if not available_players: break
+            # Add players Merlin is less certain about but are not known evil
+            player_to_add = random.choice(available_players)  # Or pick from less suspicious non-evil
+            candidates.append(player_to_add)
+
+        return sorted(list(set(candidates))[:team_size])
+
+    def mission_vote1(self, player) -> bool:  # Team approval
+        current_team = player.team_history[-1] if player.team_history else []
+        if not current_team: return random.choice([True, False])
+
+        if any(p in player.trusted_evil for p in current_team):
+            return False  # Reject if known evil is on the team
+
+        # If a seemingly good team, approve.
+        # Calculate suspicion of team members not known to be good by Merlin
+        suspicion_on_team = sum(player.suspicion_level[p] for p in current_team if
+                                p not in player.trusted_good and p not in player.trusted_evil)
+
+        # Heuristic: if high suspicion and early/mid game, might reject unless vote track is late
+        # (More complex vote track logic would require more state from Player class)
+        if suspicion_on_team > (len(current_team) * 1.5) and player.round_num < 4:
+            # Check if it's a late proposal in the round (e.g. 4th or 5th vote)
+            # This info isn't directly available in a simple way, so Merlin is generally cautious
+            return False
+
+        return True  # Approve if no known evil and not overly suspicious
+
+    # assassinate is inherited from RoleStrategy (returns -1 for Merlin)
     def mission_vote2(self) -> bool:
         """梅林任务执行：永远成功"""
         return True
 
-    def walk(self) -> tuple:
-        """梅林移动策略：保持低调，避免靠近已知邪恶玩家"""
-        current_pos = self.player.player_positions.get(self.player.index)
-        if not current_pos:
-            return tuple()
-        
-        # 获取邪恶玩家位置
-        evil_positions = [self.player.player_positions.get(p) for p in self.player.trusted_evil 
-                         if p in self.player.player_positions]
-        evil_positions = [pos for pos in evil_positions if pos]
-        
-        if evil_positions:
-            # 远离邪恶玩家
-            x, y = current_pos
-            others_pos = set(pos for pid, pos in self.player.player_positions.items() 
-                            if pos != current_pos)
-            
-            valid_moves = []
-            current_x, current_y = x, y
-            
-            for _ in range(random.randint(1, 3)):  # 梅林适度移动
-                best_moves = []
-                max_distance = -1
-                
-                directions = [("Up", -1, 0), ("Down", 1, 0), ("Left", 0, -1), ("Right", 0, 1)]
-                for direction, dx, dy in directions:
-                    new_x, new_y = current_x + dx, current_y + dy
-                    if (0 <= new_x < MAP_SIZE and 0 <= new_y < MAP_SIZE and 
-                        (new_x, new_y) not in others_pos):
-                        # 计算到最近邪恶玩家的距离
-                        min_evil_distance = min(abs(new_x - ex) + abs(new_y - ey) 
-                                              for ex, ey in evil_positions)
-                        if min_evil_distance > max_distance:
-                            max_distance = min_evil_distance
-                            best_moves = [(direction, new_x, new_y)]
-                        elif min_evil_distance == max_distance:
-                            best_moves.append((direction, new_x, new_y))
-                
-                if best_moves:
-                    direction, new_x, new_y = random.choice(best_moves)
-                    valid_moves.append(direction)
-                    current_x, current_y = new_x, new_y
-                    others_pos.add((new_x, new_y))
-                else:
-                    break
-            
-            return tuple(valid_moves)
-        else:
-            # 没有已知邪恶玩家时，随机移动
-            return random_walk(current_pos, self.player.player_positions, self.player.map, 2)
+    def walk(self, player) -> tuple:
+        """
+        Generic walking logic. Roles can override this if they have specific
+        walking patterns, but typically this is common.
+        The 'player' parameter is an instance of the main Player class.
+        """
+        origin_pos = player.player_positions.get(player.index)
+        if not origin_pos:
+            return tuple()  # Cannot walk if position is unknown
 
+        x, y = origin_pos
+        # Correctly get other players' current positions
+        others_pos = [pos for pid, pos in player.player_positions.items()
+                      if pid != player.index and pos is not None]
+
+        total_step = random.randint(0, 3)
+
+        # Check if completely surrounded by map edges or other players
+        up_blocked = (x == 0 or (x - 1, y) in others_pos)
+        down_blocked = (x == MAP_SIZE - 1 or (x + 1, y) in others_pos)  # Using global MAP_SIZE
+        left_blocked = (y == 0 or (x, y - 1) in others_pos)
+        right_blocked = (y == MAP_SIZE - 1 or (x, y + 1) in others_pos)
+
+        if up_blocked and down_blocked and left_blocked and right_blocked:
+            total_step = 0  # Player is stuck
+
+        valid_moves = []
+        current_x, current_y = x, y  # Simulate moves locally for this turn's plan
+
+        for _ in range(total_step):
+            possible_directions = []
+            # Check based on current_x, current_y after previous potential step in this walk
+            if current_x > 0 and (current_x - 1, current_y) not in others_pos:
+                possible_directions.append("Up")
+            if current_x < MAP_SIZE - 1 and (current_x + 1, current_y) not in others_pos:
+                possible_directions.append("Down")
+            if current_y > 0 and (current_x, current_y - 1) not in others_pos:
+                possible_directions.append("Left")
+            if current_y < MAP_SIZE - 1 and (current_x, current_y + 1) not in others_pos:
+                possible_directions.append("Right")
+
+            if not possible_directions:
+                break  # No valid moves from current_x, current_y
+
+            direction = random.choice(possible_directions)
+
+            # Update current_x, current_y to reflect the chosen move for this step
+            if direction == "Up":
+                current_x -= 1
+            elif direction == "Down":
+                current_x += 1
+            elif direction == "Left":
+                current_y -= 1
+            elif direction == "Right":
+                current_y += 1
+
+            valid_moves.append(direction)
+        return tuple(valid_moves)
 # 派西维尔策略
-class PercivalStrategy(RoleStrategy):
-    def decide_mission_member(self, team_size: int) -> list:
-        """派西维尔组队：测试梅林/莫甘娜候选人"""
-        candidates = [self.player.index]
-        
-        # 优先包含梅林/莫甘娜候选人进行测试
-        if 'Merlin_Morgana_candidates' in self.player.known_roles:
-            for candidate in self.player.known_roles['Merlin_Morgana_candidates']:
-                if len(candidates) < team_size and candidate not in candidates:
-                    candidates.append(candidate)
-        
-        # 选择信任度高的玩家
-        trusted_players = sorted(self.player.players, key=lambda p: self.player.suspicion_level[p])
-        for p in trusted_players:
-            if len(candidates) < team_size and p not in candidates:
-                candidates.append(p)
-        
-        return sorted(candidates[:team_size])
-    
-    def say(self) -> str:
-        """派西维尔发言：观察梅林/莫甘娜候选人"""
-        if 'Merlin_Morgana_candidates' in self.player.known_roles:
-            candidates = self.player.known_roles['Merlin_Morgana_candidates']
-            if len(candidates) == 2:
-                return f"我注意到P{candidates[0]}和P{candidates[1]}的行为很有趣，值得观察。"
-        
-        return "我在仔细观察大家的行为模式。"
-    
-    def mission_vote1(self) -> bool:
-        """派西维尔投票：利用投票测试候选人"""
-        current_team = self.player.team_history[-1][1] if self.player.team_history else []
-        
-        if 'Merlin_Morgana_candidates' in self.player.known_roles:
-            candidates = self.player.known_roles['Merlin_Morgana_candidates']
-            if any(p in candidates for p in current_team):
-                return True  # 有候选人在队伍中，支持以观察
-        
-        suspicion_score = sum(self.player.suspicion_level[p] for p in current_team)
-        return suspicion_score <= len(current_team) * 1.5
+class PercivalRoleStrategy(RoleStrategy):
+    def say(self, player) -> str:
+        self_pos = player.player_positions.get(player.index)
+        if not self_pos:
+            return "我尚未确定方位。"
 
+        if 'Merlin_Morgana_candidates' in player.known_roles and \
+                len(player.known_roles['Merlin_Morgana_candidates']) == 2:
+            candidates = player.known_roles['Merlin_Morgana_candidates']
+            c1_pos = player.player_positions.get(candidates[0])
+            c2_pos = player.player_positions.get(candidates[1])
+
+            # Try to communicate to candidates if they are in range
+            if c1_pos and player._is_in_range(c1_pos, self_pos, player.hearing_range) and \
+                    c2_pos and player._is_in_range(c2_pos, self_pos, player.hearing_range):
+                return f"P{candidates[0]}和P{candidates[1]}，你们中的一位是梅林，另一位是莫甘娜。请用你们的行动证明身份！"
+            elif c1_pos and player._is_in_range(c1_pos, self_pos, player.hearing_range):
+                return f"P{candidates[0]}，你的责任重大。我希望你能指引我们。"
+            elif c2_pos and player._is_in_range(c2_pos, self_pos, player.hearing_range):
+                return f"P{candidates[1]}，我正密切关注你。希望你是忠诚的一方。"
+            else:  # If candidates are not in range, make a general statement for others
+                return f"我已见到梅林与莫甘娜的幻象，他们是P{candidates[0]}和P{candidates[1]}。大家要仔细观察他们的行为！"
+        return "寻找梅林是我的责任。我会尽力保护他，并揭露莫甘娜的伪装。"
+
+    def decide_mission_member(self, player, team_size: int) -> list:
+        candidates = []
+        if player.index not in candidates:
+            candidates.append(player.index)
+
+        # Percival knows Merlin/Morgana candidates
+        merlin_morgana_pair = player.known_roles.get('Merlin_Morgana_candidates', [])
+
+        # Strategy: Try to include one of the Merlin/Morgana candidates to test them.
+        # Prefer the one Percival suspects less (potential Merlin).
+        if len(merlin_morgana_pair) == 2 and len(candidates) < team_size:
+            # Sort candidates by suspicion level (lower is better for Percival's Merlin guess)
+            sorted_mm_pair = sorted(merlin_morgana_pair, key=lambda p_id: player.suspicion_level[p_id])
+            potential_merlin_on_team = sorted_mm_pair[0]
+            if potential_merlin_on_team not in candidates:
+                candidates.append(potential_merlin_on_team)
+
+        # Fill with other trusted players (low suspicion, or in player.trusted_good if Percival populates this)
+        # Exclude self and already added M/M candidate from this pool for now.
+        other_players_to_consider = [p for p in player.players if p not in candidates]
+
+        # Sort by: 1. Is in trusted_good (True first), 2. Suspicion level (lower first)
+        # Percival might not have a robust 'trusted_good' like Merlin, relies more on suspicion.
+        sorted_other_players = sorted(other_players_to_consider, key=lambda p_id: (
+        not (p_id in player.trusted_good), player.suspicion_level[p_id]))
+
+        for p_id in sorted_other_players:
+            if len(candidates) < team_size:
+                # Avoid putting both Merlin/Morgana candidates on the same team if Percival is leading
+                # especially if the team is small or it's early game.
+                if p_id in merlin_morgana_pair and any(mm_cand in candidates for mm_cand in merlin_morgana_pair):
+                    if team_size <= 3 or player.round_num <= 2:  # Be cautious putting both on small/early teams
+                        continue
+                candidates.append(p_id)
+
+        # Fallback fill if necessary
+        all_player_ids = [p_id for p_id in player.players]
+        while len(candidates) < team_size:
+            available_players = [p for p in all_player_ids if p not in candidates]
+            if not available_players: break
+            # Add least suspicious from remaining
+            player_to_add = sorted(available_players, key=lambda p_add: player.suspicion_level[p_add])[0]
+            candidates.append(player_to_add)
+
+        return sorted(list(set(candidates))[:team_size])
+
+    def mission_vote1(self, player) -> bool:  # Team approval
+        current_team = player.team_history[-1] if player.team_history else []
+        if not current_team: return random.choice([True, False])
+
+        merlin_morgana_pair = player.known_roles.get('Merlin_Morgana_candidates', [])
+
+        # Count how many of the M/M pair are on the proposed team
+        mm_on_team_count = sum(1 for p_id in current_team if p_id in merlin_morgana_pair)
+
+        # If Percival is on the team, he's generally more likely to approve if it's not terrible
+        if player.index in current_team:
+            if mm_on_team_count == 1: return True  # Good for testing one candidate
+            if mm_on_team_count == 0 and len(merlin_morgana_pair) == 2:  # Neither M/M on team, but Percival is.
+                # Approve if team seems good otherwise
+                suspicion_on_team_no_mm = sum(
+                    player.suspicion_level[p] for p in current_team if p not in merlin_morgana_pair)
+                if suspicion_on_team_no_mm < (
+                        len(current_team) - (1 if player.index in current_team else 0)) * 0.5: return True  # Low sus
+
+        # If one of the M/M candidates is on the team, Percival usually approves to see their mission play.
+        if mm_on_team_count == 1:
+            return True
+
+        # If both M/M candidates are on the team, Percival might be cautious.
+        if mm_on_team_count == 2:
+            # Could be a good team if one is Merlin and other is good, or risky if one is Morgana.
+            # Percival might reject if he suspects Morgana could easily fail it or confuse things.
+            # Let's say reject if team is small and both are on it.
+            if len(current_team) <= 3: return False
+            return random.random() < 0.4  # Otherwise, less likely to approve both together
+
+        # If no M/M candidates are on the team (and Percival isn't leading/on it to test them this way)
+        # Percival might reject to try and get one of them onto a future team,
+        # or approve if the team looks very trustworthy otherwise.
+        if mm_on_team_count == 0 and len(merlin_morgana_pair) == 2:
+            if random.random() < 0.6:  # Higher chance to reject to try and get M/M on a team
+                return False
+
+        # General good player logic: approve if low suspicion
+        team_suspicion = sum(player.suspicion_level[p] for p in current_team)
+        return team_suspicion < (len(current_team) * 0.75)  # Threshold for approval
+
+    # assassinate is inherited from RoleStrategy (returns -1 for Percival)
     def mission_vote2(self) -> bool:
         """派西维尔任务执行：永远成功"""
         return True


### PR DESCRIPTION
梅林 (Merlin) 游戏策略 (MerlinRoleStrategy)

发言 (say)策略：
核心： 既要传递信息，又要保护自己。梅林非常依赖听力范围来决定发言的直接程度。
游戏早期 (前两轮左右)： 发言非常含蓄。如果发现有邪恶玩家不在自己的听力范围内，可能会旁敲侧击地暗示一下（例如，“P[邪恶玩家]的发言有点奇怪”）。通常会发表一些呼吁大家多沟通、保持警惕的通用言论。
游戏中后期： 会稍微直接一些，但依然谨慎。如果邪恶玩家不在听力范围内，可能会更明确地指出其危险性（例如，“我们必须警惕P[邪恶玩家]”）。如果邪恶玩家在听力范围内，则会使用更通用的警告（例如，“邪恶阵营正在混淆视听”）。
支持好人： 如果梅林识别出一些可信的好人（trusted_good），也会在确保安全（比如目标不在自己听力范围内）的情况下尝试支持他们。
通用发言： “我们需要一个能通过任务的队伍。” 这类发言比较中性，不易暴露身份。

组队 (decide_mission_member)策略：
核心： 挑选最不可能失败的队伍，确保任务成功。
优先选择：
梅林自己（通常好人上任务是好事）。
梅林确信的好人（trusted_good中的玩家）。
不在梅林已知邪恶名单（trusted_evil）中的玩家，即“安全玩家”。
排序逻辑： 在安全玩家中，会优先选择梅林信任度高（在trusted_good里）且嫌疑度低（suspicion_level低）的玩家。
避免： 绝对避免选择已知的邪恶玩家上任务。
补位： 如果人数不够，会从剩余的安全玩家中挑选。万不得已（理论上不应发生）才会从更广泛的玩家中选择，但始终会避开已知邪恶。

任务队伍投票 (mission_vote1)策略：
核心： 阻止包含已知邪恶爪牙的队伍，推动看起来“干净”的队伍。
必定反对： 如果队伍中有任何梅林已知的邪恶玩家，梅林会投反对票。这是梅林最重要的职责之一。
倾向赞成： 如果队伍中没有已知邪恶玩家，并且整体嫌疑度不高（特别是那些梅林认为是好人的玩家嫌疑度低），梅林会投赞成票。
谨慎情况： 如果队伍中虽然没有已知邪恶，但整体嫌疑度较高，且游戏尚处早期或中期，梅林可能会投反对票，除非当前投票轮次已经很靠后（比如第4或第5次提议，代码中此逻辑简化）。

执行任务投票 (mission_vote2)策略：
核心： 作为好人阵营，梅林在任务中总是投成功票。这是由 RoleStrategy 基类提供的默认行为，梅林继承此行为。

行走 (walk)策略：
继承自 RoleStrategy 基类的通用行走逻辑，随机移动，避免碰撞。梅林没有特殊的行走策略。

刺杀 (assassinate)策略：
梅林不执行刺杀，继承自 RoleStrategy 基类的默认行为（返回-1）。

派西维尔 (Percival) 游戏策略 (PercivalRoleStrategy)

发言 (say)策略：
核心： 围绕梅林和莫甘娜的候选人展开，试图获取信息并引导其他好人。
主要内容：
如果梅林/莫甘娜候选人（known_roles['Merlin_Morgana_candidates']）在派西维尔的听力范围内，可能会直接向他们喊话，敦促他们用行动证明身份或表明立场（例如，“P_X和P_Y，你们一个是梅林，一个是莫甘娜，请证明自己！”）。
如果候选人不在听力范围内，可能会向场上其他玩家宣告这两位候选人的身份，提醒大家注意观察。
发言会体现出自己识破伪装、保护梅林的决心。

组队 (decide_mission_member)策略：
核心： 利用组队机会测试梅林/莫甘娜候选人，收集信息。
优先选择：
派西维尔自己。
关键策略： 从两位梅林/莫甘娜候选人中选择一位加入队伍。通常会选择派西维尔感觉嫌疑度较低（即更像梅林）的那一位。目的是观察其在任务中的投票行为以及其他人的反应。
填充队员： 用派西维尔信任的其他玩家（嫌疑度低的）来填充队伍的剩余位置。
避免： 通常会避免同时将两位梅林/莫甘娜候选人都选入自己领导的队伍，尤其是在游戏早期或队伍人数较少时，因为这可能让莫甘娜更容易行事，或者让局势更混乱，不利于分辨。
补位： 如果人数不够，会从剩余玩家中选择嫌疑度最低的。

任务队伍投票 (mission_vote1)策略：
核心： 基于对梅林/莫甘娜候选人的观察和测试需求来投票。
强烈倾向赞成： 如果队伍中恰好包含一位梅林/莫甘娜候选人，派西维尔通常会投赞成票，以便观察。
谨慎对待： 如果队伍中包含两位梅林/莫甘娜候选人，派西维尔会比较谨慎。如果队伍人数较少，可能会投反对票（防止梅林和莫甘娜都在，莫甘娜捣乱）。如果队伍人数多，可能会根据自己对两位候选人的判断随机投票或小概率赞成。
自己上队： 如果派西维尔自己在队伍中：若有一位候选人也在，则赞成；若没有候选人，则看队伍整体嫌疑度决定。
无候选人在队： 如果队伍中没有梅林/莫甘娜候选人（且派西维尔自己也不在队里），派西维尔有较大几率投反对票，目的是希望后续能产生一个包含候选人的队伍配置。
通用逻辑： 在不影响观察候选人的前提下，派西维尔会赞成整体嫌疑度较低的队伍。

执行任务投票 (mission_vote2)策略：
核心： 作为好人阵营，派西维尔在任务中总是投成功票。继承自 RoleStrategy 基类的默认行为。

刺杀 (assassinate)策略：
派西维尔不执行刺杀，继承自 RoleStrategy 基类的默认行为。
